### PR TITLE
support other metric aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,32 +277,33 @@ These are the options for `DruidSource`, to be passed with `write.options()`.
 
 #### Required properties
 
-| Property | Description |
+| Property | Description |
 | --- |--- |
 | `druid.datasource` | Name of the target datasource in Druid |
 | `druid.time_column` | Name of the column in the Spark DataFrame to be translated as Druid `__time` interval. Must be of `TimestampType`. |
 | `druid.metastore.db.uri` | Druid Metadata Storage database URI |
 | `druid.metastore.db.username` | Druid Metadata Storage database username |
 | `druid.metastore.db.password` | Druid Metadata Storage database password |
+| `druid.metrics_spec` | List of metrics aggregation provided as json string, when not provided defaults to using sum aggregator for all numeric columns.|
 
 \+ Storage type specific properties depending on value of `druid.segment_storage.type`:
 
 1. **If Deep Storage is `s3` (default):**
 
-    | Property | Description |
+    | Property | Description |
     | --- |--- |
     | `druid.segment_storage.s3.bucket` | S3 bucket name for the Deep Storage | |
     | `druid.segment_storage.s3.basekey` | S3 key prefix for the Deep Storage. No trailing slashes. | |
 
 2. **If Deep Storage is `local`:**
 
-    | Property | Description |
+    | Property | Description |
     | --- |--- |
     | `druid.segment_storage.local.dir` | For local Deep Storage, absolute path to segment directory | |
 
 #### Optional properties
 
-| Property | Description | Default |
+| Property | Description | Default |
 | --- | --- | --- |
 | `druid.metastore.db.table.base` | Druid Metadata Storage database table prefix | `druid` |
 | `druid.segment_granularity` | Segment Granularity | `DAY` |

--- a/python/rovio_ingest/extensions/dataframe_extension.py
+++ b/python/rovio_ingest/extensions/dataframe_extension.py
@@ -26,6 +26,7 @@ class ConfKeys:
     # Segment config
     DATA_SOURCE = "druid.datasource"
     TIME_COLUMN = "druid.time_column"
+    METRICS_SPEC = "druid.metrics_spec"
     SEGMENT_GRANULARITY = "druid.segment_granularity"
     QUERY_GRANULARITY = "druid.query_granularity"
     BITMAP_FACTORY = "druid.bitmap_factory"

--- a/src/main/java/com/rovio/ingest/DruidDataSourceWriter.java
+++ b/src/main/java/com/rovio/ingest/DruidDataSourceWriter.java
@@ -41,7 +41,7 @@ class DruidDataSourceWriter implements BatchWrite {
     DruidDataSourceWriter(StructType schema, WriterContext param) {
         this.param = param;
         this.segmentSpec = SegmentSpec.from(param.getDataSource(),param.getTimeColumn(), param.getExcludedDimensions(),
-                param.getSegmentGranularity(), param.getQueryGranularity(), schema, param.isRollup());
+                param.getSegmentGranularity(), param.getQueryGranularity(), schema, param.isRollup(), param.getMetricsSpec());
         this.metadataUpdater = new MetadataUpdater(param);
         this.metadataUpdater.checkGranularity(segmentSpec.getDataSchema().getGranularitySpec().getSegmentGranularity());
     }

--- a/src/main/java/com/rovio/ingest/WriterContext.java
+++ b/src/main/java/com/rovio/ingest/WriterContext.java
@@ -56,6 +56,7 @@ public class WriterContext implements Serializable {
     private final boolean initDataSource;
     private final String version;
     private final boolean rollup;
+    private final String metricsSpec;
 
     private WriterContext(CaseInsensitiveStringMap options, String version) {
         this.dataSource = getOrThrow(options, ConfKeys.DATA_SOURCE);
@@ -93,6 +94,7 @@ public class WriterContext implements Serializable {
 
         this.initDataSource = options.getBoolean(ConfKeys.DATASOURCE_INIT, false);
         this.rollup = options.getBoolean(ConfKeys.SEGMENT_ROLLUP, true);
+        this.metricsSpec = options.getOrDefault(ConfKeys.METRICS_SPEC, null);
 
         this.version = version;
     }
@@ -189,11 +191,16 @@ public class WriterContext implements Serializable {
         return rollup;
     }
 
-    public static class ConfKeys {
+    public String getMetricsSpec() {
+        return metricsSpec;
+    }
+
+  public static class ConfKeys {
         public static final String DATASOURCE_INIT = "druid.datasource.init";
         // Segment config
         public static final String DATA_SOURCE = "druid.datasource";
         public static final String TIME_COLUMN = "druid.time_column";
+        public static final String METRICS_SPEC = "druid.metrics_spec";
         public static final String SEGMENT_GRANULARITY = "druid.segment_granularity";
         public static final String QUERY_GRANULARITY = "druid.query_granularity";
         public static final String BITMAP_FACTORY = "druid.bitmap_factory";

--- a/src/test/java/com/rovio/ingest/DruidDatasetExtensionsTest.java
+++ b/src/test/java/com/rovio/ingest/DruidDatasetExtensionsTest.java
@@ -35,10 +35,12 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import static com.rovio.ingest.WriterContext.ConfKeys.DATASOURCE_INIT;
+import static com.rovio.ingest.WriterContext.ConfKeys.METRICS_SPEC;
 import static com.rovio.ingest.WriterContext.ConfKeys.QUERY_GRANULARITY;
 import static com.rovio.ingest.WriterContext.ConfKeys.SEGMENT_GRANULARITY;
 import static org.apache.spark.sql.functions.column;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -270,5 +272,63 @@ public class DruidDatasetExtensionsTest extends DruidSourceBaseTest {
         data = parsed.get(0, dimensions);
         assertEquals(-1L, data.get("long_column"));
         assertEquals(-1.0, data.get("double_column"));
+    }
+
+    @Test
+    public void shouldWriteDataSegmentsWithCorrectValuesUsingPartialMetricSpec() throws IOException {
+        String metricsSpec = "[" +
+                "{\n" +
+                "   \"type\": \"longSum\",\n" +
+                "   \"name\": \"long_column\",\n" +
+                "   \"fieldName\": \"long_column\",\n" +
+                "   \"expression\": null\n" +
+                "}]";
+        Dataset<Row> dataset = spark
+                .read()
+                .format("csv")
+                .option("header", "true")
+                .option("inferSchema", "true")
+                .option("timestampFormat", "yyyy-MM-dd")
+                .load(DruidSourceBaseTest.class.getResource("/data3.csv").getPath())
+                .withColumn("date", column("date").cast(DataTypes.TimestampType));
+        dataset = DruidDatasetExtensions
+                .repartitionByDruidSegmentSize(dataset, "date", "MONTH", 5000000, false);
+        dataset.show(false);
+
+        options.put(SEGMENT_GRANULARITY, "MONTH");
+        options.put(QUERY_GRANULARITY, "SECOND");
+        options.put(METRICS_SPEC, metricsSpec);
+        dataset.write()
+                .format(DruidSource.FORMAT)
+                .mode(SaveMode.Overwrite)
+                .options(options)
+                .save();
+
+        Interval interval = new Interval(DateTime.parse("2019-10-01T00:00:00Z"), DateTime.parse("2019-11-01T00:00:00Z"));
+        String version = DateTime.now(ISOChronology.getInstanceUTC()).toString();
+        verifySegmentPath(Paths.get(testFolder.toString(), DATA_SOURCE), interval, version, 1, true);
+        verifySegmentTable(interval, version, true, 1);
+        Table<Integer, ImmutableMap<String, Object>, ImmutableMap<String, Object>> parsed = readSegmentData(Paths.get(testFolder.toString(), DATA_SOURCE), interval, version, 1, true);
+        assertEquals(2, parsed.size());
+        assertTrue(parsed.containsRow(0));
+        ImmutableMap<String, Object> dimensions = ImmutableMap.<String, Object>builder()
+                .put("string_column", "US")
+                .put("__time", DateTime.parse("2019-10-16T00:01:00Z"))
+                .put("string_date_column", "2019-10-16 00:00:00")
+                .put("boolean_column", "true")
+                .build();
+        Map<String, Object> data = parsed.get(0, dimensions);
+        assertEquals(10L, data.get("long_column"));
+        assertNull(data.get("double_column"));
+
+        dimensions = ImmutableMap.<String, Object>builder()
+                .put("string_column", "US")
+                .put("__time", DateTime.parse("2019-10-16T00:02:00Z"))
+                .put("string_date_column", "2019-10-16 00:00:00")
+                .put("boolean_column", "false")
+                .build();
+        data = parsed.get(0, dimensions);
+        assertEquals(-1L, data.get("long_column"));
+        assertNull(data.get("double_column"));
     }
 }

--- a/src/test/java/com/rovio/ingest/SegmentSpecTest.java
+++ b/src/test/java/com/rovio/ingest/SegmentSpecTest.java
@@ -18,7 +18,9 @@ package com.rovio.ingest;
 import com.rovio.ingest.model.SegmentSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
+import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,7 +41,7 @@ public class SegmentSpecTest {
     @Test
     public void shouldThrowErrorForMissingDataSource() {
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", new StructType(), true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", new StructType(), true, null));
     }
 
     @Test
@@ -47,7 +50,7 @@ public class SegmentSpecTest {
                 .add("country", DataTypes.StringType)
                 .add("metric1", DataTypes.LongType);
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -60,7 +63,7 @@ public class SegmentSpecTest {
                 .add("metric1", DataTypes.LongType)
                 .add("metric2", DataTypes.DoubleType);
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -69,7 +72,7 @@ public class SegmentSpecTest {
                 .add("__time", DataTypes.TimestampType)
                 .add("country", DataTypes.StringType);
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -78,7 +81,7 @@ public class SegmentSpecTest {
                 .add("__time", DataTypes.TimestampType)
                 .add("metric", DataTypes.LongType);
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -86,7 +89,7 @@ public class SegmentSpecTest {
         StructType schema = new StructType()
                 .add("city", DataTypes.CalendarIntervalType);
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -94,7 +97,7 @@ public class SegmentSpecTest {
         StructType schema = new StructType()
                 .add("complex", new StructType().add("id", DataTypes.StringType));
         assertThrows(IllegalArgumentException.class,
-                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true));
+                () -> SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null));
     }
 
     @Test
@@ -105,7 +108,7 @@ public class SegmentSpecTest {
                 .add("city", DataTypes.StringType)
                 .add("metric1", DataTypes.LongType)
                 .add("metric2", DataTypes.DoubleType);
-        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true);
+        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, null);
 
         assertEquals("temp", spec.getDataSchema().getDataSource());
         assertEquals("__time", spec.getTimeColumn());
@@ -135,7 +138,7 @@ public class SegmentSpecTest {
                 .add("city", DataTypes.StringType)
                 .add("metric1", DataTypes.LongType)
                 .add("metric2", DataTypes.DoubleType);
-        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.singletonList("updateTime"), "DAY", "DAY", schema, true);
+        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.singletonList("updateTime"), "DAY", "DAY", schema, true, null);
 
         assertEquals("temp", spec.getDataSchema().getDataSource());
         assertEquals("__time", spec.getTimeColumn());
@@ -163,7 +166,7 @@ public class SegmentSpecTest {
                 .add("city", DataTypes.StringType)
                 .add("metric1", DataTypes.LongType)
                 .add("metric2", DataTypes.DoubleType);
-        SegmentSpec spec = SegmentSpec.from("temp", "updateTime",  Collections.emptyList(), "DAY", "DAY", schema, true);
+        SegmentSpec spec = SegmentSpec.from("temp", "updateTime",  Collections.emptyList(), "DAY", "DAY", schema, true, null);
 
         assertEquals("temp", spec.getDataSchema().getDataSource());
         assertEquals("updateTime", spec.getTimeColumn());
@@ -192,7 +195,7 @@ public class SegmentSpecTest {
                 .add("city", DataTypes.StringType)
                 .add("metric1", DataTypes.LongType)
                 .add("metric2", DataTypes.DoubleType);
-        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, false);
+        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, false, null);
 
         assertEquals("temp", spec.getDataSchema().getDataSource());
         assertEquals("__time", spec.getTimeColumn());
@@ -208,6 +211,76 @@ public class SegmentSpecTest {
         assertTrue(dimensions.stream().allMatch(d -> DimensionSchema.ValueType.STRING == d.getValueType()));
 
         assertFalse(spec.getDataSchema().getGranularitySpec().isRollup());
+
+        assertEquals(Granularity.fromString("DAY"), spec.getDataSchema().getGranularitySpec().getSegmentGranularity());
+        assertEquals(Granularity.fromString("DAY"), spec.getDataSchema().getGranularitySpec().getQueryGranularity());
+    }
+
+    @Test
+    public void shouldFailWhenMetricsSpecIsInvalidJson() {
+        StructType schema = new StructType()
+                .add("__time", DataTypes.TimestampType)
+                .add("country", DataTypes.StringType)
+                .add("city", DataTypes.StringType)
+                .add("metric1", DataTypes.LongType)
+                .add("metric2", DataTypes.DoubleType);
+        SegmentSpec spec = SegmentSpec.from("temp", "__time", Collections.emptyList(), "DAY", "DAY", schema, true, "{}");
+        assertThrows(IllegalArgumentException.class,
+                spec::getDataSchema);
+    }
+
+    @Test
+    public void shouldSupportMetricsSpecAsJson() {
+        StructType schema = new StructType()
+                .add("updateTime", DataTypes.TimestampType)
+                .add("country", DataTypes.StringType)
+                .add("city", DataTypes.StringType)
+                .add("metric1", DataTypes.LongType)
+                .add("metric2", DataTypes.DoubleType);
+        String metricsSpec = "[" +
+                    "{\n" +
+                    "   \"type\": \"longSum\",\n" +
+                    "   \"name\": \"metric1\",\n" +
+                    "   \"fieldName\": \"metric1\",\n" +
+                    "   \"expression\": null\n" +
+                    "},\n" +
+                    "{\n" +
+                    "   \"type\": \"doubleSum\",\n" +
+                    "   \"name\": \"metric2\",\n" +
+                    "   \"fieldName\": \"metric2\",\n" +
+                    "   \"expression\": null\n" +
+                    "},\n" +
+                    "{\n" +
+                    "   \"type\": \"longMax\",\n" +
+                    "   \"name\": \"metric1_max\",\n" +
+                    "   \"fieldName\": \"metric1\",\n" +
+                    "   \"expression\": null\n" +
+                    "},\n" +
+                    "{\n" +
+                    "   \"type\": \"doubleMin\",\n" +
+                    "   \"name\": \"metric2_min\",\n" +
+                    "   \"fieldName\": \"metric2\",\n" +
+                    "   \"expression\": null\n" +
+                    "}" +
+                "]";
+        SegmentSpec spec = SegmentSpec.from("temp", "updateTime",  Collections.emptyList(), "DAY", "DAY", schema, true, metricsSpec);
+
+        assertEquals("temp", spec.getDataSchema().getDataSource());
+        assertEquals("updateTime", spec.getTimeColumn());
+
+        assertEquals(4, spec.getDataSchema().getAggregators().length);
+        assertTrue(Arrays.stream(spec.getDataSchema().getAggregators()).anyMatch(f -> f instanceof LongSumAggregatorFactory && f.getName().equals("metric1") && Objects.equals(((LongSumAggregatorFactory) f).getFieldName(), "metric1")));
+        assertTrue(Arrays.stream(spec.getDataSchema().getAggregators()).anyMatch(f -> f instanceof DoubleSumAggregatorFactory && f.getName().equals("metric2") && Objects.equals(((DoubleSumAggregatorFactory) f).getFieldName(), "metric2")));
+        assertTrue(Arrays.stream(spec.getDataSchema().getAggregators()).anyMatch(f -> f instanceof LongMaxAggregatorFactory && f.getName().equals("metric1_max") && Objects.equals(((LongMaxAggregatorFactory) f).getFieldName(), "metric1")));
+        assertTrue(Arrays.stream(spec.getDataSchema().getAggregators()).anyMatch(f -> f instanceof DoubleMinAggregatorFactory && f.getName().equals("metric2_min") && Objects.equals(((DoubleMinAggregatorFactory) f).getFieldName(), "metric2")));
+
+        List<DimensionSchema> dimensions = spec.getDataSchema().getParser().getParseSpec().getDimensionsSpec().getDimensions();
+        assertEquals(2, dimensions.size());
+        List<String> expected = Arrays.asList("country", "city");
+        assertTrue(dimensions.stream().allMatch(d -> expected.contains(d.getName())));
+        assertTrue(dimensions.stream().allMatch(d -> DimensionSchema.ValueType.STRING == d.getValueType()));
+
+        assertTrue(spec.getDataSchema().getGranularitySpec().isRollup());
 
         assertEquals(Granularity.fromString("DAY"), spec.getDataSchema().getGranularitySpec().getSegmentGranularity());
         assertEquals(Granularity.fromString("DAY"), spec.getDataSchema().getGranularitySpec().getQueryGranularity());


### PR DESCRIPTION
Support submitting metrics spec as json string with datasource options. 
This is done so as to reuse any existing ingestion spec.
Also, with this other metrics aggregators such as doubleMin, doubleMax, longMin and longMax are also supported.
This is preferred way to submit metrics spec.
The legacy behavior where the library uses sum aggregators for numeric column is retained as fallback.


