### PR TITLE
Remove segment granularity check from MetadataUpdater

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ These are the options for `DruidSource`, to be passed with `write.options()`.
 | `druid.segment.max_rows` | Max number of rows per segment | `5000000` |
 | `druid.memory.max_rows` | Max number of rows to keep in memory in spark data writer | `75000` |
 | `druid.segment_storage.type` | Type of Deep Storage to use. Allowed values: `s3`, `local`. | `s3` |
-| `druid.datasource.init` | Boolean flag for (re-)initializing Druid datasource. If `false`, `druid.segment_granularity` must match with the existing segments in the target datasource. | `false` |
+| `druid.datasource.init` | Boolean flag for (re-)initializing Druid datasource. If `true`, any pre-existing segments for the datasource is marked as unused. | `false` |
 | `druid.bitmap_factory` | Compression format for bitmap indexes. Possible values: `concise`, `roaring`. For type `roaring`, the boolean property compressRunOnSerialization is always set to `true`. `rovio-ingest` uses `concise` by default regardless of Druid library version. | `concise` |
 | `druid.segment.rollup` | Whether to rollup data during ingestion | `true` |
 

--- a/src/main/java/com/rovio/ingest/DruidDataSourceWriter.java
+++ b/src/main/java/com/rovio/ingest/DruidDataSourceWriter.java
@@ -43,7 +43,6 @@ class DruidDataSourceWriter implements BatchWrite {
         this.segmentSpec = SegmentSpec.from(param.getDataSource(),param.getTimeColumn(), param.getExcludedDimensions(),
                 param.getSegmentGranularity(), param.getQueryGranularity(), schema, param.isRollup());
         this.metadataUpdater = new MetadataUpdater(param);
-        this.metadataUpdater.checkGranularity(segmentSpec.getDataSchema().getGranularitySpec().getSegmentGranularity());
     }
 
     @Override

--- a/src/test/java/com/rovio/ingest/DruidDatasetExtensionsTest.java
+++ b/src/test/java/com/rovio/ingest/DruidDatasetExtensionsTest.java
@@ -18,7 +18,6 @@ package com.rovio.ingest;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;
 import com.rovio.ingest.extensions.java.DruidDatasetExtensions;
-import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
@@ -148,7 +147,7 @@ public class DruidDatasetExtensionsTest extends DruidSourceBaseTest {
     }
 
     @Test
-    public void saveFailsWithIncrementalAndGranularityChanges() {
+    public void saveWithIncrementalAndGranularityChanges() throws IOException {
         Dataset<Row> dataset = loadCsv(spark, "/data.csv");
         dataset = DruidDatasetExtensions
                 .repartitionByDruidSegmentSize(dataset, "date", "DAY", 5000000, false);
@@ -160,6 +159,11 @@ public class DruidDatasetExtensionsTest extends DruidSourceBaseTest {
                 .options(options)
                 .save();
 
+        Interval interval = new Interval(DateTime.parse("2019-10-16T00:00:00Z"), DateTime.parse("2019-10-18T00:00:00Z"));
+        String firstVersion = DateTime.now(ISOChronology.getInstanceUTC()).toString();
+        verifySegmentPath(Paths.get(testFolder.toString(), DATA_SOURCE), interval, firstVersion, 1, false);
+        verifySegmentTable(interval, firstVersion, true, 2);
+
         Dataset<Row> dataset2 = loadCsv(spark, "/data2.csv");
         dataset2.show(false);
         dataset2 = DruidDatasetExtensions
@@ -169,14 +173,19 @@ public class DruidDatasetExtensionsTest extends DruidSourceBaseTest {
         DateTimeUtils.setCurrentMillisFixed(VERSION_TIME_MILLIS + 60_000);
         options.put(SEGMENT_GRANULARITY, "MONTH");
 
-        DataFrameWriter<Row> writer = dataset2.write()
+        dataset2.write()
                 .format(DruidSource.FORMAT)
                 .mode(SaveMode.Overwrite)
-                .options(options);
+                .options(options)
+                .save();
 
-        Throwable thrown = assertThrows(IllegalStateException.class, writer::save);
-        assertEquals(thrown.getMessage(),
-                "Found a used segment with granularity mismatch, granularity={type=period, period=P1M, timeZone=UTC, origin=null}, start=2019-10-16T00:00:00.000Z, end=2019-10-17T00:00:00.000Z, expected end=2019-11-16T00:00:00.000Z");
+        interval = new Interval(DateTime.parse("2019-10-16T00:00:00Z"), DateTime.parse("2019-10-18T00:00:00Z"));
+        verifySegmentTable(interval, firstVersion, true, 2);
+
+        String secondVersion = DateTime.now(ISOChronology.getInstanceUTC()).toString();
+        interval = new Interval(DateTime.parse("2019-10-01T00:00:00Z"), DateTime.parse("2019-11-01T00:00:00Z"));
+        verifySegmentTable(interval, secondVersion, true, 1);
+        verifySegmentPath(Paths.get(testFolder.toString(), DATA_SOURCE), interval, secondVersion, 1, true);
     }
 
     @Test


### PR DESCRIPTION
Druid allows segments with different segment granularities for the same interval. 
Druid will always return the data from latest versioned segment for any time interval.
