### PR TITLE
Update poetry & poetry-dynamic-versioning in gh deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Install Poetry
-        run: pip install poetry==1.1.4 poetry-dynamic-versioning==0.12.1
+        run: pip install --upgrade MarkupSafe==2.0.1 poetry-core==1.0.4 poetry==1.1.8 poetry-dynamic-versioning==0.12.7
       - name: Install libkrb5-dev
         run: sudo apt-get install libkrb5-dev  # This is needed for installing pykerberos
       - name: Install python dependencies


### PR DESCRIPTION
Most importantly, pin a version of MarkupSafe that fixes the failure that was making poetry-dynamic-versioning to be skipped

The "Publish to PyPI" step [is failing](https://github.com/rovio/rovio-ingest/runs/5815552067?check_suite_focus=true) like this at the moment:
```
Publishing rovio-ingest (0.0.1) to PyPI
Error processing line 1 of /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/zzz_poetry_dynamic_versioning.pth:

  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site.py", line 168, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/poetry_dynamic_versioning/__init__.py", line 7, in <module>
      import jinja2
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
      from .environment import Environment
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
      from .defaults import BLOCK_END_STRING
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
      from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
    File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
      from markupsafe import soft_unicode
  ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/markupsafe/__init__.py)
```

Pinning `MarkupSafe==2.0.1` fixes that error.

As a bonus, minor update to poetry version.