### PR TITLE
Fix tests on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ To run tests
 
 Python code is managed by [poetry](https://python-poetry.org/).
 
+If using Apple Silicon, enable Rosetta emulation for the following to work.
+
 To create the venv with required modules, cd to the `python` subfolder and run
 
     poetry install

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <scala.minor.version>10</scala.minor.version>
         <spark.version>3.0.1</spark.version>
         <surefire.version>3.0.0-M5</surefire.version>
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -84,7 +84,17 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
             </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.8.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/rovio/ingest/DruidSourceBaseTest.java
+++ b/src/test/java/com/rovio/ingest/DruidSourceBaseTest.java
@@ -125,7 +125,7 @@ public class DruidSourceBaseTest extends SharedJavaSparkContext {
         DateTimeUtils.setCurrentMillisFixed(VERSION_TIME_MILLIS);
 
         // Create test dataset.
-        spark = SparkSession.builder().sparkContext(sc()).config("spark.sql.session.timeZone", "UTC").config("spark.master", "local").getOrCreate();
+        spark = SparkSession.builder().sparkContext(sc()).config("spark.sql.session.timeZone", "UTC").config("spark.driver.bindAddress", "127.0.0.1").config("spark.master", "local").getOrCreate();
         // This is for some udf-level unit-testing. JVM API users don't need to register this udf.
         spark.udf().register("normalizeTimeColumn", new NormalizeTimeColumnUDF(), DataTypes.LongType);
 

--- a/src/test/scala/com/rovio/ingest/DruidDatasetExtensionsSpec.scala
+++ b/src/test/scala/com/rovio/ingest/DruidDatasetExtensionsSpec.scala
@@ -51,6 +51,7 @@ class DruidDatasetExtensionsSpec extends FlatSpec with Matchers with BeforeAndAf
     SparkSession.builder()
       .appName("Spark/MLeap Parity Tests")
       .config("spark.sql.session.timeZone", "UTC")
+      .config("spark.driver.bindAddress", "127.0.0.1")
       .master("local[2]")
       .getOrCreate()
   }


### PR DESCRIPTION
Updating `testcontainers` dependency is needed to find MySQL container for arm64.

There was also an error related to jna. I found the jna-platform fix from `https://github.com/testcontainers/testcontainers-java/issues/3834`.

The spark driver `bindAddress` conf is not related to Apple Silicon, previously we've usually worked around it with some local configuration, but it's better to make sure that this repo works out of the box for anyone.