### PR TITLE
Relocate RoaringBitmap in shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,13 @@
                                         <include>com.google.common.**</include>
                                     </includes>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org</pattern>
+                                    <shadedPattern>repackaged.org.roaringbitmap</shadedPattern>
+                                    <includes>
+                                        <include>org.roaringbitmap.**</include>
+                                    </includes>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This fixes compatibility with older spark versions like 3.0.1. We already had an exclusion for RoaringBitmap from spark dependency with this comment:

> Druid library needs a newer version than what spark 3.0.1 brings

But we were missing to relocate it in the shaded jar.