### PR TITLE
gh actions: Run sudo apt-get update before install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
           python-version: '3.7'
       - name: Install Poetry
         run: pip install --upgrade MarkupSafe==2.0.1 poetry-core==1.0.4 poetry==1.1.8 poetry-dynamic-versioning==0.12.7 urllib3==1.26.15
+      - name: Update apt-get
+        run: sudo apt-get update
       - name: Install libkrb5-dev
         run: sudo apt-get install libkrb5-dev  # This is needed for installing pykerberos
       - name: Install python dependencies


### PR DESCRIPTION
Same as https://github.com/rovio/rovio-ingest/pull/49 but this time for the deploy.yml workflow.

Currently the `apt-get install libkrb5-dev` step fails. Let's see if updating the index first solves it.