### PR TITLE
Add support for array types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ The Dataset extension performs the following validations:
 * The Dataset has no columns with unknown types, unless `excludeColumnsWithUnknownTypes` is set to true
 
 The Dataset extension performs the following transformations:
-* Drops all columns of complex datatypes such as `StructType`, `MapType` or `ArrayType` as they
+* Drops all columns of complex datatypes such as `StructType` or `MapType` as they
 are not supported by `DruidSource`. This is only done if `excludeColumnsWithUnknownTypes` is set to true, otherwise validation has already failed.
+* `ArrayType` is supported with `StringType`, `LongType` and `DoubleType`
 * Converts `Date`/`Timestamp` type columns to `String`, except for the `time_column`
     - See [Druid Docs / Data types](https://druid.apache.org/docs/latest/querying/sql.html#standard-types)
 * Adds a new column `__PARTITION_TIME__` whose value is based on `time_column` column and the given [segment granularity](#segment-granularity)

--- a/src/main/java/com/rovio/ingest/model/FieldType.java
+++ b/src/main/java/com/rovio/ingest/model/FieldType.java
@@ -18,11 +18,16 @@ package com.rovio.ingest.model;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 
+import java.util.Objects;
+
 public enum FieldType {
     TIMESTAMP,
     DOUBLE,
     LONG,
-    STRING;
+    STRING,
+    ARRAY_OF_DOUBLE,
+    ARRAY_OF_LONG,
+    ARRAY_OF_STRING;
 
     public static FieldType from(DataType dataType) {
         if (isNumericType(dataType)) {
@@ -41,6 +46,18 @@ public enum FieldType {
             return STRING;
         }
 
+        if (isArrayOfNumericType(dataType)) {
+            return ARRAY_OF_LONG;
+        }
+
+        if (isArrayOfDoubleType(dataType)) {
+            return ARRAY_OF_DOUBLE;
+        }
+
+        if (isArrayOfStringType(dataType)) {
+            return ARRAY_OF_STRING;
+        }
+
         throw new IllegalArgumentException("Unsupported Type " + dataType);
     }
 
@@ -53,6 +70,22 @@ public enum FieldType {
                 || dataType == DataTypes.IntegerType
                 || dataType == DataTypes.ShortType
                 || dataType == DataTypes.ByteType;
+    }
+
+    private static boolean isArrayOfNumericType(DataType dataType) {
+        return Objects.equals(dataType, DataTypes.createArrayType(DataTypes.LongType))
+                || Objects.equals(dataType, DataTypes.createArrayType(DataTypes.IntegerType))
+                || Objects.equals(dataType, DataTypes.createArrayType(DataTypes.ShortType))
+                || Objects.equals(dataType, DataTypes.createArrayType(DataTypes.ByteType));
+    }
+
+    private static boolean isArrayOfDoubleType(DataType dataType) {
+        return Objects.equals(dataType, DataTypes.createArrayType(DataTypes.DoubleType))
+                || Objects.equals(dataType, DataTypes.createArrayType(DataTypes.FloatType));
+    }
+    private static boolean isArrayOfStringType(DataType dataType) {
+        return Objects.equals(dataType, DataTypes.createArrayType(DataTypes.StringType))
+                || Objects.equals(dataType, DataTypes.createArrayType(DataTypes.BooleanType));
     }
 
 }

--- a/src/main/scala/com/rovio/ingest/extensions/DruidDatasetExtensions.scala
+++ b/src/main/scala/com/rovio/ingest/extensions/DruidDatasetExtensions.scala
@@ -51,8 +51,8 @@ object DruidDatasetExtensions {
    */
   @SerialVersionUID(1L)
   implicit class DruidDataset(dataset: Dataset[Row]) extends Serializable {
-    private val METRIC_TYPES = Array(FloatType, DoubleType, IntegerType, LongType, ShortType, ByteType)
-    private val DIMENSION_TYPES = Array(StringType, DateType, TimestampType, BooleanType)
+    private val METRIC_TYPES = Array(FloatType, DoubleType, IntegerType, LongType, ShortType, ByteType, ArrayType(LongType), ArrayType(DoubleType))
+    private val DIMENSION_TYPES = Array(StringType, DateType, TimestampType, BooleanType, ArrayType(StringType))
     private val log = LoggerFactory.getLogger(classOf[DruidDataset])
 
     /**
@@ -66,7 +66,7 @@ object DruidDatasetExtensions {
      * <p>
      * The method performs the following transformations:
      * <ul>
-     * <li>Drops all columns of complex datatypes such as `StructType`, `MapType` or `ArrayType` as they are not
+     * <li>Drops all columns of complex datatypes such as `StructType` or `MapType` as they are not
      * supported by `DruidSource`. This is only done if `excludeColumnsWithUnknownTypes` is set to true,
      * otherwise validation has already failed.</li>
      * <li>Adds a new column `__PARTITION_TIME__` whose value is based on `time_column` column and the given segment

--- a/src/test/scala/com/rovio/ingest/DruidDatasetExtensionsSpec.scala
+++ b/src/test/scala/com/rovio/ingest/DruidDatasetExtensionsSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 // must define classes outside of the actual test methods, otherwise spark can't find them
 case class KpiRow(date: String, country: String, dau: Integer, revenue: Double, is_segmented: Boolean)
-case class RowWithUnsupportedType(date: String, country: String, dau: Integer, labels: Array[String])
+case class RowWithUnsupportedType(date: String, country: String, dau: Integer, values: Array[Long])
 case class PartitionedRow(date: String, country: String, dau: Integer, revenue: Double, `__PARTITION_NUM__`: Integer)
 case class ExpectedRow(`__PARTITION_TIME__`: String, `__PARTITION_NUM__`: Integer, count: Integer)
 
@@ -221,7 +221,7 @@ class DruidDatasetExtensionsSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   it should "exclude columns with unsupported types" in {
     val ds = Seq(RowWithUnsupportedType(
-      date="2019-10-17", country="US", dau=50, labels=Array("A", "B"))).toDS
+      date="2019-10-17", country="US", dau=50, values=Array(1L, 2L))).toDS
       .withColumn("date", 'date.cast(DataTypes.TimestampType))
     val result = ds.repartitionByDruidSegmentSize("date", "DAY", 2, excludeColumnsWithUnknownTypes = true)
 
@@ -237,7 +237,7 @@ class DruidDatasetExtensionsSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   it should "throw exception from unsupported types by default" in {
     val ds = Seq(RowWithUnsupportedType(
-      date="2019-10-17", country="US", dau=50, labels=Array("A", "B"))).toDS
+      date="2019-10-17", country="US", dau=50, values=Array(1L, 2L))).toDS
       .withColumn("date", 'date.cast(DataTypes.TimestampType))
     assertThrows[IllegalArgumentException] {
       ds.repartitionByDruidSegmentSize("date", "DAY", 2)


### PR DESCRIPTION
Resolves issues https://github.com/rovio/rovio-ingest/issues/40 and https://github.com/rovio/rovio-ingest/issues/51.

Support is added for `ARRAY<STRING>`, `ARRAY<LONG>` & `ARRAY<DOUBLE>`.

Related documentation:
* https://druid.apache.org/docs/latest/querying/arrays
* https://druid.apache.org/docs/latest/querying/multi-value-dimensions/

This code was extracted from https://github.com/fabricebaranski/rovio-ingest/commit/9c6eb40e1b7b00ac9f5126e38bb27c8e644ef173, as agreed with the author. Thank you for the contribution!