### PR TITLE
More config options for HDFS storage (e.g. Kerberos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,14 +314,22 @@ These are the options for `DruidSource`, to be passed with `write.options()`.
 
     | Property | Description |
     | --- |--- |
-    | `druid.segment_storage.s3.bucket` | S3 bucket name for the Deep Storage | |
-    | `druid.segment_storage.s3.basekey` | S3 key prefix for the Deep Storage. No trailing slashes. | |
+    | `druid.segment_storage.s3.bucket` | S3 bucket name for the Deep Storage |
+    | `druid.segment_storage.s3.basekey` | S3 key prefix for the Deep Storage. No trailing slashes. |
 
 2. **If Deep Storage is `local`:**
 
     | Property | Description |
     | --- |--- |
-    | `druid.segment_storage.local.dir` | For local Deep Storage, absolute path to segment directory | |
+    | `druid.segment_storage.local.dir` | For local Deep Storage, absolute path to segment directory |
+
+3. **If Deep Storage is `hdfs`:**
+
+   | Property | Description |
+   | --- | --- |
+   | `druid.segment_storage.hdfs.dir` | For hdfs Deep Storage, absolute path to segment directory |
+   | `druid.segment_storage.hdfs.security.kerberos.principal` | Kerberos principal |
+   | `druid.segment_storage.hdfs.security.kerberos.keytab` | Kerberos keytab |
 
 #### Optional properties
 
@@ -336,7 +344,6 @@ These are the options for `DruidSource`, to be passed with `write.options()`.
 | `druid.memory.max_rows` | Max number of rows to keep in memory in spark data writer | `75000` |
 | `druid.segment_storage.type` | Type of Deep Storage to use. Allowed values: `s3`, `local`, `hdfs`. | `s3` |
 | `druid.segment_storage.s3.disableacl` | Whether to disable ACL in S3 config. | `false` |
-| `druid.segment_storage.hdfs.dir` | Hdfs segment storage location | `""` |
 | `druid.datasource.init` | Boolean flag for (re-)initializing Druid datasource. If `true`, any pre-existing segments for the datasource is marked as unused. | `false` |
 | `druid.bitmap_factory` | Compression format for bitmap indexes. Possible values: `concise`, `roaring`. For type `roaring`, the boolean property compressRunOnSerialization is always set to `true`. `rovio-ingest` uses `concise` by default regardless of Druid library version. | `concise` |
 | `druid.segment.rollup` | Whether to rollup data during ingestion | `true` |

--- a/src/main/java/com/rovio/ingest/WriterContext.java
+++ b/src/main/java/com/rovio/ingest/WriterContext.java
@@ -55,6 +55,12 @@ public class WriterContext implements Serializable {
     private final String s3BaseKey;
     private final boolean s3DisableAcl;
     private final String localDir;
+    private final String hdfsDir;
+    private final String hdfsCoreSitePath;
+    private final String hdfsHdfsSitePath;
+    private final String hdfsDefaultFS;
+    private final String hdfsSecurityKerberosPrincipal;
+    private final String hdfsSecurityKerberosKeytab;
     private final String deepStorageType;
     private final boolean initDataSource;
     private final String version;
@@ -64,7 +70,6 @@ public class WriterContext implements Serializable {
     private final String dimensionsSpec;
     private final String metricsSpec;
     private final String transformSpec;
-    private String getHdfsStorageDir;
 
     private WriterContext(CaseInsensitiveStringMap options, String version) {
         this.dataSource = getOrThrow(options, ConfKeys.DATA_SOURCE);
@@ -97,7 +102,12 @@ public class WriterContext implements Serializable {
         this.s3BaseKey = options.getOrDefault(ConfKeys.DEEP_STORAGE_S3_BASE_KEY, null);
         this.s3DisableAcl = options.getBoolean(ConfKeys.DEEP_STORAGE_S3_DISABLE_ACL, false);
         this.localDir = options.getOrDefault(ConfKeys.DEEP_STORAGE_LOCAL_DIRECTORY, null);
-        this.getHdfsStorageDir = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_DIRECTORY, null);
+        this.hdfsDir = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_STORAGE_DIRECTORY, null);
+        this.hdfsCoreSitePath = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_CORE_SITE_PATH, null);
+        this.hdfsHdfsSitePath = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_HDFS_SITE_PATH, null);
+        this.hdfsDefaultFS = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_DEFAULT_FS, null);
+        this.hdfsSecurityKerberosPrincipal = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_SECURITY_KERBEROS_PRINCIPAL, null);
+        this.hdfsSecurityKerberosKeytab = options.getOrDefault(ConfKeys.DEEP_STORAGE_HDFS_SECURITY_KERBEROS_KEYTAB, null);
 
         this.deepStorageType = options.getOrDefault(ConfKeys.DEEP_STORAGE_TYPE, DEFAULT_DRUID_DEEP_STORAGE_TYPE);
         Preconditions.checkArgument(Arrays.asList("s3", "local", "hdfs").contains(this.deepStorageType),
@@ -194,8 +204,28 @@ public class WriterContext implements Serializable {
         return localDir;
     }
 
-    public String getDeepStorageType() {
-        return deepStorageType;
+    public String getHdfsDir() {
+        return hdfsDir;
+    }
+
+    public String getHdfsCoreSitePath() {
+        return hdfsCoreSitePath;
+    }
+
+    public String getHdfsHdfsSitePath() {
+        return hdfsHdfsSitePath;
+    }
+
+    public String getHdfsDefaultFS() {
+        return hdfsDefaultFS;
+    }
+
+    public String getHdfsSecurityKerberosPrincipal() {
+        return hdfsSecurityKerberosPrincipal;
+    }
+
+    public String getHdfsSecurityKerberosKeytab() {
+        return hdfsSecurityKerberosKeytab;
     }
 
     public boolean isInitDataSource() {
@@ -238,10 +268,6 @@ public class WriterContext implements Serializable {
         return transformSpec;
     }
 
-    public String getHdfsStorageDir() {
-        return getHdfsStorageDir;
-    }
-
     public static class ConfKeys {
         public static final String DATASOURCE_INIT = "druid.datasource.init";
         // Segment config
@@ -274,6 +300,11 @@ public class WriterContext implements Serializable {
         // Local config (only for testing)
         public static final String DEEP_STORAGE_LOCAL_DIRECTORY = "druid.segment_storage.local.dir";
         // HDFS config
-        public static final String DEEP_STORAGE_HDFS_DIRECTORY = "druid.segment_storage.hdfs.dir";
+        public static final String DEEP_STORAGE_HDFS_STORAGE_DIRECTORY = "druid.segment_storage.hdfs.dir";
+        public static final String DEEP_STORAGE_HDFS_CORE_SITE_PATH = "druid.segment_storage.hdfs.core.site.path";
+        public static final String DEEP_STORAGE_HDFS_HDFS_SITE_PATH = "druid.segment_storage.hdfs.hdfs.site.path";
+        public static final String DEEP_STORAGE_HDFS_DEFAULT_FS = "druid.segment_storage.hdfs.default.fs";
+        public static final String DEEP_STORAGE_HDFS_SECURITY_KERBEROS_PRINCIPAL = "druid.segment_storage.hdfs.security.kerberos.principal";
+        public static final String DEEP_STORAGE_HDFS_SECURITY_KERBEROS_KEYTAB = "druid.segment_storage.hdfs.security.kerberos.keytab";
     }
 }


### PR DESCRIPTION
This adds to the implementation that already exists, and even more so marks https://github.com/rovio/rovio-ingest/issues/47 resolved.

This code was extracted from https://github.com/fabricebaranski/rovio-ingest/commit/9c6eb40e1b7b00ac9f5126e38bb27c8e644ef173, as agreed with the author. Thank you for the contribution!