### PR TITLE
OSSRH Migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,14 +590,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <tokenAuth>true</tokenAuth>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>
@@ -607,17 +607,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <reporting>
         <plugins>


### PR DESCRIPTION
OSSRH is reaching end of life on June 30, 2025. This PR updates the project's Maven Central publishing mechanism to use the newer Sonatype Central Publishing Maven Plugin:
- Replaced the deprecated nexus-staging-maven-plugin with the new central-publishing-maven-plugin
- Updated configuration parameters to work with the new plugin
- Removed old Nexus-specific configuration options
- Removed the distributionManagement section which is no longer needed with the new plugin