### PR TITLE
Revert "Skip poetry publish error if done before"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,13 +57,7 @@ jobs:
         run: poetry build
         working-directory: ./python
       - name: Publish to PyPI
-        run: |
-          poetry publish -u '__token__' -p '${{ secrets.PYPI_TOKEN }}' 2>&1 | tee publish.log
-          if grep -q "400 File already exists" publish.log; then
-            echo "File already exists, skipping error."
-            exit 0
-          fi
-          exit ${PIPESTATUS[0]}
+        run: poetry publish -u '__token__' -p '${{ secrets.PYPI_TOKEN }}'
         working-directory: ./python
 
       - name: Set up Apache Maven Central


### PR DESCRIPTION
This reverts commit 31d89ee935ab7b3c89db03f1c4a266147e077526.

This made the poetry publish step fail when there's actually a new version to publish and publishing succeeded. So at least the shell script doesn't work as it was.