### PR TITLE
Exclude python/.venv and python/dist from license header check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,8 @@
                             <excludes>
                                 <exclude>src/test/resources/**</exclude>
                                 <exclude>src/main/resources/**</exclude>
+                                <exclude>python/.venv/**</exclude>
+                                <exclude>python/dist/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>


### PR DESCRIPTION
Publish action failed on the licence check: https://github.com/rovio/rovio-ingest/actions/runs/24395626061/job/71252582602#step:15:37201

The license-maven-plugin does not respect .gitignore, so these generated/external directories must be explicitly excluded in pom.xml.