### PR TITLE
test: Suppress DeprecationWarnings from PySpark's internal use of deprecated pandas APIs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,6 +39,13 @@ dev = [
     "safety>=3.2.7",
 ]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    # PySpark uses deprecated pandas APIs internally (distutils.version.LooseVersion,
+    # is_datetime64tz_dtype). If fixed in a future PySpark version, remove this filter.
+    "ignore::DeprecationWarning:pyspark",
+]
+
 [tool.uv-dynamic-versioning]
 enable = true
 metadata = false


### PR DESCRIPTION
Suppress `DeprecationWarning`s from PySpark during pytest runs. These warnings come from PySpark's internal use of deprecated pandas APIs (`distutils.version.LooseVersion` and `is_datetime64tz_dtype`) and are not
 caused by our code.

## Example warnings suppressed

    tests/dataframe_extension_test.py::test_repartition_by_druid_segment_size
      /Users/juhoautio/code/rovio-ingest/python/.venv/lib/python3.12/site-packages/pyspark/sql/pandas/utils.py:36: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
        if LooseVersion(pandas.__version__) < LooseVersion(minimum_pandas_version):
    
    tests/dataframe_extension_test.py::test_repartition_by_druid_segment_size
      /Users/juhoautio/code/rovio-ingest/python/.venv/lib/python3.12/site-packages/pyspark/sql/pandas/types.py:562: DeprecationWarning: is_datetime64tz_dtype is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.DatetimeTZDtype)` instead.
        if not is_datetime64tz_dtype(pser.dtype):