### PR TITLE
build: Upgrade maven-shade-plugin 3.2.4 → 3.5.3 for Java 17 class file support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
After updating dependencies, gh action deploy workflow started failing. This should fix it.