### PR TITLE
build: Upgrade from Java 8 to Java 17

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,11 @@ jobs:
           # uv-dynamic-versioning needs the full history. latest commit is not enough.
           fetch-depth: '0'
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
       - name: Run maven tests & package
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,11 +9,11 @@ jobs:
       - name: Set Environment variables
         run: echo "SPARK_LOCAL_IP=localhost" >> $GITHUB_ENV
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
       - name: Run maven tests
         run: mvn -B test --file pom.xml
       - name: Setup Python

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Overview diagram:
 
 rovio-ingest requires
 * Apache Spark 3*
-* JDK8 (8u92+ or later).
+* JDK 17 or later.
 * Python >=3.11 (for the Python package). Note: Spark 3.x may not work with Python >3.12.
 * Linux or MacOS.
 * Git repo must be cloned under a path that doesn't have spaces.

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <mysql.connector.version>9.2.0</mysql.connector.version>
         <postgresql.version>42.6.1</postgresql.version>
         <aws.sdk.version>1.12.261</aws.sdk.version>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <antlr4.version>4.9.3</antlr4.version>
         <jackson.version>2.18.6</jackson.version>
         <slf4j.version>2.0.12</slf4j.version>
@@ -399,8 +399,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
                 <executions>
                     <execution>
@@ -508,6 +507,23 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <!-- Required for Spark on Java 17: open internal JDK packages blocked by JPMS -->
+                    <argLine>
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens=java.base/java.net=ALL-UNNAMED
+                        --add-opens=java.base/java.nio=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+                        --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                        --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                    </argLine>
                     <!-- By default maven only finds *Test (may depend on maven version)
                          Make sure *Spec is included -->
                     <includes>


### PR DESCRIPTION
Switch compiler target from Java 8 to Java 17, using the modern `<release>` flag in maven-compiler-plugin. Update CI workflows and README to reflect the new requirement.