### PR TITLE
Fix deploy workflow using JDK 8 for Maven publish step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/setup-java@v2
         with: # running setup-java again overwrites the settings.xml
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
           server-id: central # Value of the publishingServerId param for central-publishing-maven-plugin
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy


### PR DESCRIPTION
After the java-17 upgrade, the publish step still switched to JDK 8 to configure settings.xml, causing `--release 17` to be an invalid flag.